### PR TITLE
Parse #prbuddy_focus from PR body

### DIFF
--- a/prbuddy/review.py
+++ b/prbuddy/review.py
@@ -42,6 +42,15 @@ openai.api_key = OPENAI_API_KEY
 gh   = Github(GITHUB_TOKEN)
 repo = gh.get_repo(GITHUB_REPOSITORY)
 pr   = repo.get_pull(PR_NUMBER)
+pr_body = pr.body or ""
+body_focus_areas = []
+for line in pr_body.splitlines():
+    match = re.search(r"#prbuddy_focus:\s*(.*)", line, re.I)
+    if match:
+        body_focus_areas = [a.strip() for a in match.group(1).split(',') if a.strip()]
+        break
+# Merge focus areas from PR body and environment variable
+focus_areas = sorted(set(focus_areas + body_focus_areas))
 print(f"🔎 Reviewing PR #{PR_NUMBER} in {GITHUB_REPOSITORY}")
 
 def ensure_label(name, color="ededed"):


### PR DESCRIPTION
## Summary
- fetch PR body
- parse `#prbuddy_focus:` from description
- merge with env `PRBUDDY_FOCUS_AREAS`
- apply combined focus list when building prompts

## Testing
- `python -m py_compile prbuddy/review.py`
- `pip install flake8` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_683ff6adb968832d968b42498865f980